### PR TITLE
Switch Storybook deployment trigger to manual

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -7,7 +7,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # This ensures the workflow can push to the repository
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,8 +1,7 @@
 name: Deploy Storybook
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Monorepo System Example
 
+[📘 Docs](https://felipegangrel.github.io/monorepo-system)
+
 ### Creating a Github Personal Token
 
 1. Create a Personal Access Token with read and write permissions for packages.


### PR DESCRIPTION
---

**Description:**

- [ ] Update Storybook deployment trigger to manual mode.
- [ ] Add documentation link to the README.
- [ ] Simplify permissions comment in deploy workflow.