### PR TITLE
Add locale inference utility for date formatting

### DIFF
--- a/packages/intl/src/date-formater/date-formater.ts
+++ b/packages/intl/src/date-formater/date-formater.ts
@@ -1,24 +1,37 @@
-import { format } from 'date-fns';
-import { de, enUS as en, es, ptBR as pt } from 'date-fns/locale';
+import { format, type FormatOptions } from 'date-fns';
 
+import { inferLocaleFromLanguage } from '@/infer-locale-from-language';
 import type { LanguageOption } from '@/translation-manager';
 
-function getLocale(language: LanguageOption) {
-  switch (language) {
-    case 'en':
-      return en;
-    case 'de':
-      return de;
-    case 'es':
-      return es;
-    case 'pt':
-      return pt;
-  }
-}
-
-function makeDateFormatter(language: LanguageOption) {
-  return function (date: number | string | Date, dateStr: string) {
-    return format(date, dateStr, { locale: getLocale(language) });
+/**
+ * Creates a date formatter function specific to a given language.
+ *
+ * @param {LanguageOption} language - The language option used to infer the locale for formatting.
+ * @returns {(date: number | string | Date, dateStr: string, formatOptions?: FormatOptions) => string}
+ *          A function that formats a date based on the specified date string and format options.
+ *
+ * The returned function takes three arguments:
+ * - `date`: The date to format (can be a `number`, `string`, or `Date` object).
+ * - `dateStr`: The format string specifying how the date should be formatted.
+ * - `formatOptions` (optional): Additional options for formatting the date.
+ */
+function makeDateFormatter(
+  language: LanguageOption
+): (
+  date: number | string | Date,
+  dateStr: string,
+  formatOptions?: FormatOptions
+) => string {
+  const locale = inferLocaleFromLanguage(language);
+  return function (
+    date: number | string | Date,
+    dateStr: string,
+    formatOptions?: FormatOptions
+  ) {
+    return format(date, dateStr, {
+      locale,
+      ...formatOptions,
+    });
   };
 }
 

--- a/packages/intl/src/index.ts
+++ b/packages/intl/src/index.ts
@@ -1,2 +1,3 @@
 export * from './date-formater';
+export * from './infer-locale-by-language';
 export * from './translation-manager';

--- a/packages/intl/src/index.ts
+++ b/packages/intl/src/index.ts
@@ -1,3 +1,3 @@
 export * from './date-formater';
-export * from './infer-locale-by-language';
+export * from './infer-locale-from-language';
 export * from './translation-manager';

--- a/packages/intl/src/infer-locale-from-language/index.ts
+++ b/packages/intl/src/infer-locale-from-language/index.ts
@@ -1,0 +1,1 @@
+export * from './infer-locale-from-language';

--- a/packages/intl/src/infer-locale-from-language/infer-locale-from-language.spec.ts
+++ b/packages/intl/src/infer-locale-from-language/infer-locale-from-language.spec.ts
@@ -1,0 +1,30 @@
+import { de, enUS as en, es, ptBR as pt } from 'date-fns/locale';
+
+import { inferLocaleFromLanguage } from './infer-locale-from-language';
+
+describe('inferLocaleFromLanguage function', () => {
+  it('should return the "en" locale for the "en" language', () => {
+    const result = inferLocaleFromLanguage('en');
+    expect(result).toBe(en);
+  });
+
+  it('should return the "de" locale for the "de" language', () => {
+    const result = inferLocaleFromLanguage('de');
+    expect(result).toBe(de);
+  });
+
+  it('should return the "es" locale for the "es" language', () => {
+    const result = inferLocaleFromLanguage('es');
+    expect(result).toBe(es);
+  });
+
+  it('should return the "pt" locale for the "pt" language', () => {
+    const result = inferLocaleFromLanguage('pt');
+    expect(result).toBe(pt);
+  });
+
+  it('should return the "pt" locale as the default case for unsupported languages', () => {
+    const result = inferLocaleFromLanguage('unsupported_language' as any);
+    expect(result).toBe(pt);
+  });
+});

--- a/packages/intl/src/infer-locale-from-language/infer-locale-from-language.ts
+++ b/packages/intl/src/infer-locale-from-language/infer-locale-from-language.ts
@@ -1,0 +1,26 @@
+import { de, enUS as en, es, Locale, ptBR as pt } from 'date-fns/locale';
+
+import type { LanguageOption } from '@/translation-manager';
+
+/**
+ * Infers the date-fns locale object based on the provided language option.
+ *
+ * @param {LanguageOption} language - The language option to infer locale for.
+ *                                     Supported values: 'en', 'de', 'es', 'pt'.
+ * @returns {Locale} The corresponding date-fns locale object for the given language.
+ */
+function inferLocaleFromLanguage(language: LanguageOption): Locale {
+  switch (language) {
+    case 'en':
+      return en;
+    case 'de':
+      return de;
+    case 'es':
+      return es;
+    case 'pt':
+    default:
+      return pt;
+  }
+}
+
+export { inferLocaleFromLanguage };


### PR DESCRIPTION
### Description

This pull request introduces the `inferLocaleFromLanguage` utility function to map languages to `date-fns` locales. It integrates the new utility with the date formatter, replacing the inline locale mapping to improve reusability and maintainability. Unit tests are added to ensure the utility behaves as expected.