### PR TITLE
Add language support for Calendar and DatePicker

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -14,7 +14,6 @@ const config: StorybookConfig = {
   addons: [
     getAbsolutePath('@storybook/addon-onboarding'),
     getAbsolutePath('@storybook/addon-essentials'),
-    getAbsolutePath('@chromatic-com/storybook'),
     getAbsolutePath('@storybook/addon-interactions'),
     getAbsolutePath('@storybook/addon-a11y'),
     getAbsolutePath('@storybook/addon-themes'),

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,7 +22,6 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@chromatic-com/storybook": "catalog:",
     "@eslint/js": "catalog:",
     "@storybook/addon-a11y": "catalog:",
     "@storybook/addon-essentials": "catalog:",

--- a/apps/docs/src/stories/core-ui/calendar.stories.tsx
+++ b/apps/docs/src/stories/core-ui/calendar.stories.tsx
@@ -16,6 +16,10 @@ const meta: Meta<typeof Calendar> = {
   tags: ['autodocs'],
   args: {
     showOutsideDays: true,
+    language: 'pt',
+  },
+  argTypes: {
+    language: { control: 'select', options: ['en', 'pt', 'es', 'de'] },
   },
   parameters: {
     layout: 'centered',
@@ -31,9 +35,7 @@ const today = new Date();
 export const Example: Story = {
   args: {
     mode: 'single',
-    onSelect: (value) => {
-      console.log(value);
-    },
+    onSelect: console.log,
   },
 };
 

--- a/apps/docs/src/stories/react-hook-form/date-picker.stories.tsx
+++ b/apps/docs/src/stories/react-hook-form/date-picker.stories.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@felipegangrel/core-ui';
 import { DatePicker, Form } from '@felipegangrel/react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -12,6 +13,10 @@ const meta: Meta<typeof DatePicker> = {
   title: 'react-hook-form/DatePicker',
   component: DatePicker,
   tags: ['autodocs'],
+  argTypes: {
+    language: { control: 'select', options: ['en', 'pt', 'es', 'de'] },
+    clearable: { control: 'boolean' },
+  },
   parameters: {
     layout: 'centered',
     docs: {
@@ -24,7 +29,9 @@ const meta: Meta<typeof DatePicker> = {
 
 export default meta;
 
-export const Example = () => {
+type Story = StoryObj<typeof DatePicker>;
+
+const Template = (args: React.ComponentProps<typeof DatePicker>) => {
   const formSchema = z.object({
     date: z.date(),
   });
@@ -51,7 +58,7 @@ export const Example = () => {
               <Form.Item>
                 <Form.Label>Date</Form.Label>
                 <DatePicker
-                  clearable
+                  {...args}
                   value={field.value}
                   onChange={field.onChange}
                 />
@@ -64,4 +71,12 @@ export const Example = () => {
       </Form>
     </div>
   );
+};
+
+export const Example: Story = {
+  args: {
+    language: 'en',
+    clearable: true,
+  },
+  render: (args) => <Template {...args} />,
 };

--- a/packages/core-ui/src/components/ui/calendar/calendar.tsx
+++ b/packages/core-ui/src/components/ui/calendar/calendar.tsx
@@ -3,18 +3,27 @@ import * as React from 'react';
 import { DayPicker } from 'react-day-picker';
 
 import { buttonVariants } from '@/components/ui/button';
+import { inferLocaleFromLanguage, type LanguageOption } from '@/lib/intl';
 import { cn } from '@/lib/utils';
 
-type CalendarProps = React.ComponentProps<typeof DayPicker>;
+type CalendarProps = React.ComponentProps<typeof DayPicker> & {
+  /**
+   * Optional language parameter to infer the locale property
+   * for the Calendar
+   */
+  language?: LanguageOption;
+};
 
 function Calendar({
   className,
   classNames,
   showOutsideDays = true,
+  language,
   ...props
 }: CalendarProps) {
   return (
     <DayPicker
+      locale={language && inferLocaleFromLanguage(language)}
       showOutsideDays={showOutsideDays}
       className={cn('core-p-3', className)}
       classNames={{

--- a/packages/core-ui/src/lib/intl.ts
+++ b/packages/core-ui/src/lib/intl.ts
@@ -1,4 +1,5 @@
 import {
+  inferLocaleFromLanguage,
   type LanguageOption,
   makeDateFormatter,
   TranslationManager,
@@ -13,5 +14,5 @@ const intl = TranslationManager.create({
   },
 } as const).setFallbackLanguage('pt');
 
-export { intl, makeDateFormatter };
+export { inferLocaleFromLanguage, intl, makeDateFormatter };
 export type { LanguageOption };

--- a/packages/react-hook-form/src/components/date-picker/date-picker.tsx
+++ b/packages/react-hook-form/src/components/date-picker/date-picker.tsx
@@ -1,10 +1,14 @@
 import { Button, Calendar, Popover } from '@felipegangrel/core-ui';
-import { format } from 'date-fns';
 import { CalendarIcon, XIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { Form } from '@/components/form';
-import { intl, LanguageOption } from '@/lib/intl';
+import {
+  inferLocaleFromLanguage,
+  intl,
+  LanguageOption,
+  makeDateFormatter,
+} from '@/lib/intl';
 import { cn } from '@/lib/utils';
 
 const dictionary = intl.makeDictionary({
@@ -27,17 +31,19 @@ type DatePickerProps = React.HTMLAttributes<HTMLElement> & {
 
 const DatePicker = ({
   className,
-  language,
   placeholder,
   clearable,
-  value: selected,
   onChange,
+  value: selected,
+  language = 'pt',
   dateFormat = 'PPP',
 }: DatePickerProps) => {
   const t = intl.makeTranslator({
     dictionary,
     language,
   });
+
+  const d = makeDateFormatter(language);
 
   const onClear = React.useCallback(
     (event: React.MouseEvent) => {
@@ -60,9 +66,7 @@ const DatePicker = ({
             )}
           >
             <CalendarIcon className="rhf-mr-2 rhf-h-4 rhf-w-4" />
-            {selected
-              ? format(selected, dateFormat)
-              : placeholder || t('pickADate')}
+            {selected ? d(selected, dateFormat) : placeholder || t('pickADate')}
             {clearable && selected && (
               <span className="rhf-ml-auto" onClick={onClear}>
                 <XIcon className="rhf-ml-2 rhf-h-4 rhf-w-4 rhf-text-muted-foreground hover:rhf-text-foreground" />
@@ -74,6 +78,7 @@ const DatePicker = ({
       </Popover.Trigger>
       <Popover.Content className="rhf-w-auto rhf-p-0">
         <Calendar
+          locale={inferLocaleFromLanguage(language)}
           mode="single"
           selected={selected}
           onSelect={onChange}

--- a/packages/react-hook-form/src/lib/intl.ts
+++ b/packages/react-hook-form/src/lib/intl.ts
@@ -1,6 +1,11 @@
-import { type LanguageOption, TranslationManager } from '@felipegangrel/intl';
+import {
+  inferLocaleFromLanguage,
+  type LanguageOption,
+  makeDateFormatter,
+  TranslationManager,
+} from '@felipegangrel/intl';
 
 const intl = TranslationManager.create().setFallbackLanguage('pt');
 
-export { intl };
+export { inferLocaleFromLanguage, intl, makeDateFormatter };
 export type { LanguageOption };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@changesets/cli':
-      specifier: ^2.27.10
-      version: 2.27.12
-    '@chromatic-com/storybook':
-      specifier: ^3.2.2
-      version: 3.2.4
     '@eslint/js':
       specifier: ^9.20.0
       version: 9.20.0
@@ -21,57 +15,6 @@ catalogs:
     '@hookform/resolvers':
       specifier: ^3.10.0
       version: 3.10.0
-    '@next/eslint-plugin-next':
-      specifier: ^15.0.4
-      version: 15.1.6
-    '@radix-ui/react-accordion':
-      specifier: ^1.2.2
-      version: 1.2.3
-    '@radix-ui/react-alert-dialog':
-      specifier: ^1.1.2
-      version: 1.1.6
-    '@radix-ui/react-aspect-ratio':
-      specifier: ^1.1.1
-      version: 1.1.2
-    '@radix-ui/react-avatar':
-      specifier: ^1.1.2
-      version: 1.1.3
-    '@radix-ui/react-checkbox':
-      specifier: ^1.1.3
-      version: 1.1.4
-    '@radix-ui/react-collapsible':
-      specifier: ^1.1.2
-      version: 1.1.3
-    '@radix-ui/react-context-menu':
-      specifier: ^2.2.5
-      version: 2.2.6
-    '@radix-ui/react-dialog':
-      specifier: ^1.1.4
-      version: 1.1.6
-    '@radix-ui/react-dropdown-menu':
-      specifier: ^2.1.5
-      version: 2.1.6
-    '@radix-ui/react-hover-card':
-      specifier: ^1.1.5
-      version: 1.1.6
-    '@radix-ui/react-label':
-      specifier: 2.1.1
-      version: 2.1.1
-    '@radix-ui/react-menubar':
-      specifier: ^1.1.5
-      version: 1.1.6
-    '@radix-ui/react-popover':
-      specifier: ^1.1.4
-      version: 1.1.6
-    '@radix-ui/react-select':
-      specifier: ^2.1.4
-      version: 2.1.6
-    '@radix-ui/react-slot':
-      specifier: ^1.1.0
-      version: 1.1.2
-    '@radix-ui/react-switch':
-      specifier: ^1.1.2
-      version: 1.1.3
     '@storybook/addon-a11y':
       specifier: ^8.4.7
       version: 8.5.3
@@ -108,30 +51,9 @@ catalogs:
     '@storybook/theming':
       specifier: ^8.4.7
       version: 8.5.3
-    '@swc/core':
-      specifier: ^1.10.1
-      version: 1.10.14
-    '@swc/jest':
-      specifier: ^0.2.37
-      version: 0.2.37
-    '@tanstack/match-sorter-utils':
-      specifier: ^8.19.4
-      version: 8.19.4
     '@tanstack/react-table':
       specifier: ^8.20.6
       version: 8.20.6
-    '@testing-library/jest-dom':
-      specifier: ^6.6.3
-      version: 6.6.3
-    '@testing-library/react':
-      specifier: ^16.1.0
-      version: 16.2.0
-    '@testing-library/user-event':
-      specifier: ^14.5.2
-      version: 14.6.1
-    '@types/jest':
-      specifier: ^29.5.14
-      version: 29.5.14
     '@types/node':
       specifier: ^22.10.5
       version: 22.13.1
@@ -147,75 +69,30 @@ catalogs:
     clsx:
       specifier: ^2.1.1
       version: 2.1.1
-    cmdk:
-      specifier: ^1.0.0
-      version: 1.0.4
     date-fns:
       specifier: ^4.1.0
       version: 4.1.0
-    embla-carousel-react:
-      specifier: ^8.5.2
-      version: 8.5.2
     eslint:
       specifier: ^9.16.0
       version: 9.19.0
-    eslint-config-prettier:
-      specifier: ^9.1.0
-      version: 9.1.0
-    eslint-plugin-only-warn:
-      specifier: ^1.1.0
-      version: 1.1.0
-    eslint-plugin-react:
-      specifier: ^7.37.2
-      version: 7.37.4
     eslint-plugin-react-hooks:
       specifier: ^5.1.0
       version: 5.1.0
     eslint-plugin-react-refresh:
       specifier: ^0.4.14
       version: 0.4.18
-    eslint-plugin-simple-import-sort:
-      specifier: ^12.1.1
-      version: 12.1.1
     eslint-plugin-storybook:
       specifier: ^0.11.1
       version: 0.11.2
-    eslint-plugin-turbo:
-      specifier: ^2.3.3
-      version: 2.4.0
     globals:
       specifier: ^15.13.0
       version: 15.14.0
-    input-otp:
-      specifier: ^1.4.2
-      version: 1.4.2
-    jest:
-      specifier: ^29.7.0
-      version: 29.7.0
-    jest-environment-jsdom:
-      specifier: ^29.7.0
-      version: 29.7.0
-    jest-environment-node:
-      specifier: ^29.7.0
-      version: 29.7.0
-    jest-matchmedia-mock:
-      specifier: ^1.1.0
-      version: 1.1.0
-    lefthook:
-      specifier: ^1.9.0
-      version: 1.10.10
     lucide-react:
       specifier: ^0.468.0
       version: 0.468.0
     postcss:
       specifier: ^8.4.49
       version: 8.5.1
-    prettier:
-      specifier: ^3.4.2
-      version: 3.4.2
-    prettier-plugin-tailwindcss:
-      specifier: ^0.6.9
-      version: 0.6.11
     react-day-picker:
       specifier: ^8.10.1
       version: 8.10.1
@@ -231,42 +108,18 @@ catalogs:
     storybook-dark-mode:
       specifier: ^4.0.2
       version: 4.0.2
-    syncpack:
-      specifier: ^13.0.0
-      version: 13.0.2
     tailwind-merge:
       specifier: ^2.5.5
       version: 2.6.0
     tailwindcss:
       specifier: ^3.4.16
       version: 3.4.17
-    tailwindcss-animate:
-      specifier: ^1.0.7
-      version: 1.0.7
-    timezone-mock:
-      specifier: ^1.3.6
-      version: 1.3.6
     ts-node:
       specifier: ^10.9.2
       version: 10.9.2
-    tsup:
-      specifier: ^8.3.5
-      version: 8.3.6
-    tsx:
-      specifier: ^4.19.2
-      version: 4.19.2
-    turbo:
-      specifier: ^2.3.3
-      version: 2.4.0
-    typescript:
-      specifier: ~5.6.2
-      version: 5.6.3
     typescript-eslint:
       specifier: ^8.17.0
       version: 8.23.0
-    vaul:
-      specifier: ^1.1.2
-      version: 1.1.2
     vite:
       specifier: ^6.0.1
       version: 6.1.0
@@ -376,9 +229,6 @@ importers:
         specifier: 'catalog:'
         version: 3.24.1
     devDependencies:
-      '@chromatic-com/storybook':
-        specifier: 'catalog:'
-        version: 3.2.4(react@19.0.0)(storybook@8.5.3(prettier@3.4.2))
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.20.0
@@ -1183,12 +1033,6 @@ packages:
 
   '@changesets/write@0.3.2':
     resolution: {integrity: sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==}
-
-  '@chromatic-com/storybook@3.2.4':
-    resolution: {integrity: sha512-5/bOOYxfwZ2BktXeqcCpOVAoR6UCoeART5t9FVy22hoo8F291zOuX4y3SDgm10B1GVU/ZTtJWPT2X9wZFlxYLg==}
-    engines: {node: '>=16.0.0', yarn: '>=1.22.18'}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3164,18 +3008,6 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chromatic@11.25.2:
-    resolution: {integrity: sha512-/9eQWn6BU1iFsop86t8Au21IksTRxwXAl7if8YHD05L2AbuMjClLWZo5cZojqrJHGKDhTqfrC2X2xE4uSm0iKw==}
-    hasBin: true
-    peerDependencies:
-      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
-      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
-    peerDependenciesMeta:
-      '@chromatic-com/cypress':
-        optional: true
-      '@chromatic-com/playwright':
-        optional: true
-
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -3743,10 +3575,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  filesize@10.1.6:
-    resolution: {integrity: sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==}
-    engines: {node: '>= 10.4.0'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -4392,9 +4220,6 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
-  jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -4989,12 +4814,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  react-confetti@6.2.2:
-    resolution: {integrity: sha512-K+kTyOPgX+ZujMZ+Rmb7pZdHBvg+DzinG/w4Eh52WOB8/pfO38efnnrtEZNJmjTvLxc16RBYO+tPM68Fg8viBA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      react: ^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0
 
   react-day-picker@8.10.1:
     resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
@@ -5612,9 +5431,6 @@ packages:
     resolution: {integrity: sha512-ah/yQp2oMif1X0u7fBJ4MLMygnkbKnW5O8SG6pJvloPCpHfFoZctkSVQiJ3VnvNTq71V2JJIdwmOeu1i34OQyg==}
     hasBin: true
 
-  tween-functions@1.2.0:
-    resolution: {integrity: sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==}
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5677,10 +5493,6 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
-
-  universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
 
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
@@ -6311,19 +6123,6 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
-
-  '@chromatic-com/storybook@3.2.4(react@19.0.0)(storybook@8.5.3(prettier@3.4.2))':
-    dependencies:
-      chromatic: 11.25.2
-      filesize: 10.1.6
-      jsonfile: 6.1.0
-      react-confetti: 6.2.2(react@19.0.0)
-      storybook: 8.5.3(prettier@3.4.2)
-      strip-ansi: 7.1.0
-    transitivePeerDependencies:
-      - '@chromatic-com/cypress'
-      - '@chromatic-com/playwright'
-      - react
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8396,8 +8195,6 @@ snapshots:
     dependencies:
       readdirp: 4.1.1
 
-  chromatic@11.25.2: {}
-
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.3: {}
@@ -9073,8 +8870,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  filesize@10.1.6: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -9938,12 +9733,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonfile@6.1.0:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.8
@@ -10415,11 +10204,6 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
-
-  react-confetti@6.2.2(react@19.0.0):
-    dependencies:
-      react: 19.0.0
-      tween-functions: 1.2.0
 
   react-day-picker@8.10.1(date-fns@4.1.0)(react@19.0.0):
     dependencies:
@@ -11153,8 +10937,6 @@ snapshots:
       turbo-windows-64: 2.4.0
       turbo-windows-arm64: 2.4.0
 
-  tween-functions@1.2.0: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -11224,8 +11006,6 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@0.2.0: {}
-
-  universalify@2.0.1: {}
 
   unplugin@1.16.1:
     dependencies:


### PR DESCRIPTION
### Description
- Added `language` prop for both Calendar and DatePicker to enable locale-based configurations.
- Updated utilities to handle locale inference and enhanced date formatting accordingly.
- Updated related story files for validation and demonstration.
- Removed unused dependencies (`@chromatic-com/storybook`) to streamline the project.