### PR TITLE
Add documentation for intl utilities and remove unused import

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@faker-js/faker": "catalog:",
     "@felipegangrel/core-ui": "workspace:*",
+    "@felipegangrel/intl": "workspace:*",
     "@felipegangrel/react-hook-form": "workspace:*",
     "@hookform/resolvers": "catalog:",
     "@storybook/preview-api": "catalog:",

--- a/apps/docs/src/stories/intl/make-date-formatter.mdx
+++ b/apps/docs/src/stories/intl/make-date-formatter.mdx
@@ -1,0 +1,305 @@
+import { Meta, Markdown } from '@storybook/blocks';
+
+<Meta title="INTL/Make Date Formatter" />
+
+# Make Date Formatter
+
+The **makeDateFormatter** utility allows developers to format dates for any language, making it ideal for internationalized applications. It builds on the `date-fns` library for flexible formatting.
+
+
+## Examples
+
+### Example: Basic Usage
+
+Use `makeDateFormatter` to create a formatter for English (`'en'`) and use it to format the current date:
+
+
+```typescript
+import { makeDateFormatter } from '@felipegangrel/intl';
+
+const formatDate = makeDateFormatter('en');
+
+// Format today's date using the formatter
+const today = new Date();
+const formattedDate = formatDate(today, 'MMMM dd, yyyy');
+
+console.log(formattedDate); // e.g., "October 30, 2023"
+```
+
+### Example: Using Format Options
+
+Format dates with optional `date-fns` options for greater customization:
+
+  ```typescript
+import {makeDateFormatter} from '@felipegangrel/intl';
+
+const formatDate = makeDateFormatter('en');
+
+// Use additional formatting options
+const formattedDate = formatDate(new Date(), 'MMMM dd, yyyy', {
+  useAdditionalDayOfYearTokens: true,
+});
+
+console.log(formattedDate); // e.g., "October 30, 2023"
+  ```
+
+<table>
+  <thead>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><strong><code>language</code></strong></td>
+    <td><code>LanguageOption</code></td>
+    <td>Language option (e.g., <code>'en'</code>, <code>'pt'</code>). Used to infer the locale.</td>
+  </tr>
+  <tr>
+    <td><strong><code>date</code></strong></td>
+    <td><code>number | string | Date</code></td>
+    <td>The date to be formatted.</td>
+  </tr>
+  <tr>
+    <td><strong><code>dateStr</code></strong></td>
+    <td><code>string</code></td>
+    <td>Format string for the date (compatible with <code>date-fns</code> format tokens).</td>
+  </tr>
+  <tr>
+    <td><strong><code>options</code></strong></td>
+    <td><code>FormatOptions</code> (optional)</td>
+    <td>Additional formatting options (passed to <code>date-fns</code>).</td>
+  </tr>
+  </tbody>
+</table>
+
+## Notes
+
+- The `makeDateFormatter` relies on `date-fns` for formatting. Ensure the relevant `date-fns` locale is included in your project.
+- The `inferLocaleFromLanguage` helper determines how locale strings (like `'en'` or `'pt'`) map to `date-fns` locales.
+- If incorrectly configured, using an unsupported locale may cause runtime errors.
+
+## Dependencies
+
+Ensure `date-fns` is installed and properly configured with locale imports.
+
+## date-fns available formats
+
+<table>
+  <thead>
+  <tr>
+    <th>Token</th>
+    <th>Category</th>
+    <th>Description</th>
+    <th>Example</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><code>yyyy</code></td>
+    <td>Year</td>
+    <td>Four-digit year</td>
+    <td>2023</td>
+  </tr>
+  <tr>
+    <td><code>yy</code></td>
+    <td>Year</td>
+    <td>Two-digit year</td>
+    <td>23</td>
+  </tr>
+  <tr>
+    <td><code>MMMM</code></td>
+    <td>Month</td>
+    <td>Full month name</td>
+    <td>October</td>
+  </tr>
+  <tr>
+    <td><code>MMM</code></td>
+    <td>Month</td>
+    <td>Abbreviated month name</td>
+    <td>Oct</td>
+  </tr>
+  <tr>
+    <td><code>MM</code></td>
+    <td>Month</td>
+    <td>Two-digit month</td>
+    <td>10</td>
+  </tr>
+  <tr>
+    <td><code>M</code></td>
+    <td>Month</td>
+    <td>Month number without zero-padding</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <td><code>dd</code></td>
+    <td>Day</td>
+    <td>Two-digit day of the month</td>
+    <td>30</td>
+  </tr>
+  <tr>
+    <td><code>d</code></td>
+    <td>Day</td>
+    <td>Day of the month without zero-padding</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <td><code>do</code></td>
+    <td>Day</td>
+    <td>Ordinal day of the month</td>
+    <td>30th</td>
+  </tr>
+  <tr>
+    <td><code>EEEE</code></td>
+    <td>Day of Week</td>
+    <td>Full day of the week</td>
+    <td>Monday</td>
+  </tr>
+  <tr>
+    <td><code>EEE</code></td>
+    <td>Day of Week</td>
+    <td>Abbreviated day of the week</td>
+    <td>Mon</td>
+  </tr>
+  <tr>
+    <td><code>EE</code></td>
+    <td>Day of Week</td>
+    <td>Short day of the week</td>
+    <td>Mo</td>
+  </tr>
+  <tr>
+    <td><code>HH</code></td>
+    <td>Hour</td>
+    <td>Two-digit hour (24-hour clock)</td>
+    <td>14</td>
+  </tr>
+  <tr>
+    <td><code>H</code></td>
+    <td>Hour</td>
+    <td>Hour (24-hour clock) without zero-padding</td>
+    <td>9</td>
+  </tr>
+  <tr>
+    <td><code>hh</code></td>
+    <td>Hour</td>
+    <td>Two-digit hour (12-hour clock)</td>
+    <td>02</td>
+  </tr>
+  <tr>
+    <td><code>h</code></td>
+    <td>Hour</td>
+    <td>Hour (12-hour clock) without zero-padding</td>
+    <td>9</td>
+  </tr>
+  <tr>
+    <td><code>mm</code></td>
+    <td>Minute</td>
+    <td>Two-digit minutes</td>
+    <td>45</td>
+  </tr>
+  <tr>
+    <td><code>m</code></td>
+    <td>Minute</td>
+    <td>Minutes without zero-padding</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <td><code>ss</code></td>
+    <td>Second</td>
+    <td>Two-digit seconds</td>
+    <td>30</td>
+  </tr>
+  <tr>
+    <td><code>s</code></td>
+    <td>Second</td>
+    <td>Seconds without zero-padding</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <td><code>a</code></td>
+    <td>Period</td>
+    <td>AM/PM</td>
+    <td>PM</td>
+  </tr>
+  <tr>
+    <td><code>aa</code></td>
+    <td>Period</td>
+    <td>Lowercase am/pm</td>
+    <td>pm</td>
+  </tr>
+  <tr>
+    <td><code>Z</code></td>
+    <td>Timezone</td>
+    <td>GMT offset with colon</td>
+    <td>+05:00</td>
+  </tr>
+  <tr>
+    <td><code>ZZ</code></td>
+    <td>Timezone</td>
+    <td>GMT offset without colon</td>
+    <td>+0500</td>
+  </tr>
+  <tr>
+    <td><code>zzz</code></td>
+    <td>Timezone</td>
+    <td>Abbreviated timezone</td>
+    <td>EST</td>
+  </tr>
+  <tr>
+    <td><code>OOOO</code></td>
+    <td>Timezone</td>
+    <td>GMT with formatting</td>
+    <td>GMT+5</td>
+  </tr>
+  <tr>
+    <td><code>P</code></td>
+    <td>Localized</td>
+    <td>Short localized date format</td>
+    <td>10/30/2023</td>
+  </tr>
+  <tr>
+    <td><code>PP</code></td>
+    <td>Localized</td>
+    <td>Medium localized date format</td>
+    <td>Oct 30, 2023</td>
+  </tr>
+  <tr>
+    <td><code>PPP</code></td>
+    <td>Localized</td>
+    <td>Long localized date format</td>
+    <td>October 30, 2023</td>
+  </tr>
+  <tr>
+    <td><code>PPPP</code></td>
+    <td>Localized</td>
+    <td>Full localized date format (including day of week)</td>
+    <td>Monday, October 30, 2023</td>
+  </tr>
+  <tr>
+    <td><code>p</code></td>
+    <td>Localized</td>
+    <td>Short localized time format</td>
+    <td>2:45 PM</td>
+  </tr>
+  <tr>
+    <td><code>pp</code></td>
+    <td>Localized</td>
+    <td>Medium localized time format</td>
+    <td>2:45:30 PM</td>
+  </tr>
+  <tr>
+    <td><code>ppp</code></td>
+    <td>Localized</td>
+    <td>Long localized time format</td>
+    <td>2:45 PM UTC+5</td>
+  </tr>
+  <tr>
+    <td><code>pppp</code></td>
+    <td>Localized</td>
+    <td>Full localized time format (with timezone)</td>
+    <td>2:45 PM GMT+5</td>
+  </tr>
+  </tbody>
+</table>

--- a/apps/docs/src/stories/intl/make-date-formatter.mdx
+++ b/apps/docs/src/stories/intl/make-date-formatter.mdx
@@ -1,4 +1,4 @@
-import { Meta, Markdown } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 <Meta title="INTL/Make Date Formatter" />
 

--- a/apps/docs/src/stories/intl/translation-manager.mdx
+++ b/apps/docs/src/stories/intl/translation-manager.mdx
@@ -1,0 +1,136 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="INTL/Translation Manager" />
+
+# Translation Manager
+The **Translation Manager** is a streamlined class designed to simplify the process of managing translations in your application. By initializing the manager with a flexible base dictionary and defining a fallback language, the Translation Manager allows you to deliver consistent and dynamic multilingual experiences.
+
+## Why Use Translation Manager?
+Translation can be a tedious aspect of localization in any application. The **Translation Manager** empowers developers by offering:
+1. **Scalability**: Maintain a clean structure with base dictionaries and extensions.
+2. **Reusable Translations**: Share base dictionaries across your application, and extend them only where necessary.
+3. **Dynamic Flexibility**: Replace text dynamically with placeholders for user personalization.
+4. **Fallback Language**: Always ensure a consistent experience if translations in the desired language are missing.
+
+## Quick Start
+Begin by creating an instance of the **Translation Manager** with a base dictionary—this will act as your foundation for managing global translations.
+
+### Simple Initialization Example
+Here’s how you can craft a robust, reusable translation object for your app-wide usage:
+
+```typescript
+// src/lib/intl.ts
+import { TranslationManager } from '@felipegangrel/intl';
+
+const intl = TranslationManager.create({
+  cancelButton: {
+    en: 'Cancel',
+    pt: 'Cancelar',
+    es: 'Cancelar',
+    de: 'Abbrechen',
+  },
+} as const).setFallbackLanguage('en'); // Default language is English.
+
+export { intl };
+```
+You’ve now defined a base dictionary containing translations for a "Cancel" button. The fallback ensures an English translation is used, even if a translation for a specific language is unavailable.
+
+### Generating Translation Functions
+Use the **Translation Manager** to generate a translator function tailored for your dictionary and target language. This can be directly applied within components:
+```tsx
+// src/components/MyComponent.tsx
+import { intl } from '@/lib/intl';
+
+const MyComponent = () => {
+  const t = intl.makeTranslator({
+    dictionary: intl.baseDictionary,
+    language: 'en', // Language can optionally override the fallback.
+  });
+
+  return (
+    <main>
+      <button>{t('cancelButton')}</button> // Output: Cancel
+    </main>
+  );
+};
+```
+
+## Enhance Specific Components with Dictionary Extensions
+Rather than cluttering your base dictionary with contextual translations, you can create **extensions**—focused dictionaries with translations specific to individual components or modules.
+
+### Example: Using an Extended Dictionary
+```tsx
+// src/components/MyComponent.tsx
+import { intl } from '@/lib/intl';
+
+const dictionary = intl.makeDictionaryExtension({
+  submitButton: {
+    en: 'Submit',
+    pt: 'Enviar',
+    es: 'Enviar',
+    de: 'Einreichen',
+  },
+} as const);
+
+const MyComponent = () => {
+  const t = intl.makeTranslator({
+    dictionary,
+    language: 'pt', // Portuguese translation for this component.
+  });
+
+  return (
+    <main>
+      <button>{t('cancelButton')}</button> // Output: Cancelar
+      <button>{t('submitButton')}</button> // Output: Enviar
+    </main>
+  );
+};
+```
+Now, the component gains extended functionality while leveraging the translations from the base dictionary.
+
+## Personalizing Text with Dynamic Replacements
+Personalization is a cornerstone of user experience. **Translation Manager** supports text replacements through dynamic placeholders, enabling more context-appropriate and user-specific messages.
+
+### How It Works:
+1. **Define Placeholders** in your translations using curly braces (`{}`), e.g., `{name}`.
+2. **Replace Dynamically** by passing an object with the key-value pairs for replacements when calling the translation function.
+
+#### Example: Dynamic Message Injection
+In scenarios like greeting customers by name or updating time-sensitive messages, placeholders can be a game-changer:
+
+```tsx
+// src/components/MyComponent.tsx
+import { intl } from '@/lib/intl';
+
+const dictionary = intl.makeDictionary({
+  clientGreeting: {
+    en: `Hello, {name}. Your purchase has been dispatched.`,
+    pt: `Olá, {name}. Sua compra foi enviada.`,
+    es: `Hola, {name}. Su compra ha sido enviada.`,
+    de: `Hallo, {name}. Ihr Einkauf wurde verschickt.`,
+  },
+} as const);
+
+const MyComponent = () => {
+  const t = intl.makeTranslator({
+    dictionary,
+    language: 'pt', // Portuguese for this example.
+  });
+
+  return (
+    <main>
+      <div>{t('clientGreeting', { name: 'John' })}</div>
+      // Output: Olá, John. Sua compra foi enviada.
+    </main>
+  );
+};
+```
+
+### When to Use Text Replacements?
+This feature is especially useful for:
+- **Personalized Greetings**: "Hello, `{name}`!"
+- **Transactional Updates**: "Your order of `{item}` is on the way."
+- **Notifications**: "You have `{count}` unread messages."
+
+## Closing Thoughts
+The **Translation Manager** is designed to handle localization in a modular and intuitive way, enabling scalability, reuse, and flexibility. Whether managing straightforward translations, extending dictionaries, or inserting dynamic values, you are equipped for both simple use cases and complex multilingual interfaces. The manager’s fallback mechanism ensures seamless experiences, even when translations are partial or missing.

--- a/packages/intl/src/translation-manager/translation-manager.ts
+++ b/packages/intl/src/translation-manager/translation-manager.ts
@@ -68,28 +68,35 @@ class TranslationManager<T extends Dictionary> {
   }) {
     const { dictionary, language = this.fallbackLanguage } = options;
 
+    const findValue = (key: keyof T) => {
+      return (dictionary[key] as DictionaryEntry)[language]
+        ? (dictionary[key] as DictionaryEntry)[language]
+        : (dictionary[key] as DictionaryEntry)[this.fallbackLanguage];
+    };
+
+    const replaceValue = (
+      value: string,
+      replacer: Record<string, string | number>
+    ) => {
+      return value.replace(/\{(\w+)}/g, (match, replacerKey) => {
+        if (replacerKey in replacer) {
+          return String(replacer[replacerKey]);
+        }
+        return match;
+      });
+    };
+
     return (
       key: keyof T,
       replacer?: Record<string, string | number>
     ): string => {
-      const value = (dictionary[key] as DictionaryEntry)[language]
-        ? (dictionary[key] as DictionaryEntry)[language]
-        : (dictionary[key] as DictionaryEntry)[this.fallbackLanguage];
+      const value = findValue(key);
 
       if (!value) {
         return '';
       }
 
-      if (replacer) {
-        return value.replace(/\{(\w+)}/g, (match, replacerKey) => {
-          if (replacerKey in replacer) {
-            return String(replacer[replacerKey]);
-          }
-          return match;
-        });
-      }
-
-      return value;
+      return replacer ? replaceValue(value, replacer) : value;
     };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       '@felipegangrel/core-ui':
         specifier: workspace:*
         version: link:../../packages/core-ui
+      '@felipegangrel/intl':
+        specifier: workspace:*
+        version: link:../../packages/intl
       '@felipegangrel/react-hook-form':
         specifier: workspace:*
         version: link:../../packages/react-hook-form


### PR DESCRIPTION
- **Added** Storybook documentation for `makeDateFormatter` and `TranslationManager` with examples.
- **Enhanced** the `makeTranslator` method for improved modularity and dynamic text replacements.
- **Removed** unused Markdown import from `make-date-formatter.mdx`.
- **Added** `@felipegangrel/intl` as a dependency for documentation